### PR TITLE
feat: CRUD for Supplier

### DIFF
--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -9,7 +9,7 @@
 
 <MudLayout>
     <Sidebar></Sidebar>
-    <MudMainContent Class="h-full">
+    <MudMainContent Class="h-full pt-10!">
         @Body
     </MudMainContent>
 </MudLayout>

--- a/Pages/Supplier/Shared/CreateSupplierDialog.razor
+++ b/Pages/Supplier/Shared/CreateSupplierDialog.razor
@@ -1,0 +1,81 @@
+@using GreenStore.Clients
+@using System.ComponentModel.DataAnnotations
+
+<MudDialog @bind-Visible="IsVisible" Options="dialogOptions">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Thêm nhà cung cấp</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudForm @ref="form" @bind-IsValid="isValid">
+            <MudTextField @bind-Value="Model.Name" Label="Tên" Required="true" 
+                RequiredError="Tên không được để trống" Class="mt-3" />
+            <MudTextField @bind-Value="Model.Phone" Label="SĐT" Required="true"
+                RequiredError="SĐT không được để trống" Class="mt-3"
+                Validation="@(new Func<string?, string?>(ValidatePhone))" />
+            <MudTextField @bind-Value="Model.Email" Label="Email" Required="true"
+                RequiredError="Email không được để trống" Class="mt-3" 
+                InputType="InputType.Email"
+                Validation="@(new Func<string?, string?>(ValidateEmail))" />
+            <MudTextField @bind-Value="Model.Address" Label="Địa chỉ" Required="true"
+                RequiredError="Địa chỉ không được để trống" Lines="2" Class="mt-3" />
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Hủy</MudButton>
+        <MudButton Color="Color.Primary" OnClick="Submit" Disabled="@(!isValid)">Thêm</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private DialogOptions dialogOptions = new DialogOptions
+    {
+        MaxWidth = MaxWidth.Medium,
+        FullWidth = true
+    };
+
+    private MudForm form = null!;
+    private bool isValid;
+
+    [Parameter]
+    public bool IsVisible { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> IsVisibleChanged { get; set; }
+
+    [Parameter]
+    public SupplierDto Model { get; set; } = new SupplierDto();
+
+    [Parameter]
+    public EventCallback<SupplierDto> OnSubmit { get; set; }
+
+    private string? ValidatePhone(string? phone)
+    {
+        if (string.IsNullOrWhiteSpace(phone)) return null;
+        if (!System.Text.RegularExpressions.Regex.IsMatch(phone, @"^[0-9]{10,11}$"))
+            return "SĐT phải có 10-11 chữ số";
+        return null;
+    }
+
+    private string? ValidateEmail(string? email)
+    {
+        if (string.IsNullOrWhiteSpace(email)) return null;
+        if (!new EmailAddressAttribute().IsValid(email))
+            return "Email không hợp lệ";
+        return null;
+    }
+
+    private async Task Cancel()
+    {
+        IsVisible = false;
+        await IsVisibleChanged.InvokeAsync(IsVisible);
+    }
+
+    private async Task Submit()
+    {
+        await form.Validate();
+        if (isValid)
+        {
+            await OnSubmit.InvokeAsync(Model);
+        }
+    }
+}

--- a/Pages/Supplier/Shared/UpdateSupplierDialog.razor
+++ b/Pages/Supplier/Shared/UpdateSupplierDialog.razor
@@ -1,0 +1,81 @@
+@using GreenStore.Clients
+@using System.ComponentModel.DataAnnotations
+
+<MudDialog @bind-Visible="IsVisible" Options="dialogOptions">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Chỉnh sửa nhà cung cấp</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudForm @ref="form" @bind-IsValid="isValid">
+            <MudTextField @bind-Value="Model.Name" Label="Tên" Required="true" 
+                RequiredError="Tên không được để trống" Class="mt-3" />
+            <MudTextField @bind-Value="Model.Phone" Label="SĐT" Required="true"
+                RequiredError="SĐT không được để trống" Class="mt-3"
+                Validation="@(new Func<string?, string?>(ValidatePhone))" />
+            <MudTextField @bind-Value="Model.Email" Label="Email" Required="true"
+                RequiredError="Email không được để trống" Class="mt-3" 
+                InputType="InputType.Email"
+                Validation="@(new Func<string?, string?>(ValidateEmail))" />
+            <MudTextField @bind-Value="Model.Address" Label="Địa chỉ" Required="true"
+                RequiredError="Địa chỉ không được để trống" Lines="2" Class="mt-3" />
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Hủy</MudButton>
+        <MudButton Color="Color.Primary" OnClick="Submit" Disabled="@(!isValid)">Lưu</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private DialogOptions dialogOptions = new DialogOptions
+    {
+        MaxWidth = MaxWidth.Medium,
+        FullWidth = true
+    };
+
+    private MudForm form = null!;
+    private bool isValid;
+
+    [Parameter]
+    public bool IsVisible { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> IsVisibleChanged { get; set; }
+
+    [Parameter]
+    public SupplierDto Model { get; set; } = new SupplierDto();
+
+    [Parameter]
+    public EventCallback<SupplierDto> OnSubmit { get; set; }
+
+    private string? ValidatePhone(string? phone)
+    {
+        if (string.IsNullOrWhiteSpace(phone)) return null;
+        if (!System.Text.RegularExpressions.Regex.IsMatch(phone, @"^[0-9]{10,11}$"))
+            return "SĐT phải có 10-11 chữ số";
+        return null;
+    }
+
+    private string? ValidateEmail(string? email)
+    {
+        if (string.IsNullOrWhiteSpace(email)) return null;
+        if (!new EmailAddressAttribute().IsValid(email))
+            return "Email không hợp lệ";
+        return null;
+    }
+
+    private async Task Cancel()
+    {
+        IsVisible = false;
+        await IsVisibleChanged.InvokeAsync(IsVisible);
+    }
+
+    private async Task Submit()
+    {
+        await form.Validate();
+        if (isValid)
+        {
+            await OnSubmit.InvokeAsync(Model);
+        }
+    }
+}

--- a/Pages/Supplier/SupplierPage.razor
+++ b/Pages/Supplier/SupplierPage.razor
@@ -1,0 +1,348 @@
+@page "/suppliers"
+@using GreenStore.Clients
+@using GreenStore.Shared.Pagination
+@using GreenStore.Shared.Table
+@using GreenStore.Pages.Supplier.Shared
+@inject IGreenStoreApiClient Api
+@inject ISnackbar Toast
+@inject IDialogService DialogService
+
+<PageTitle>Suppliers</PageTitle>
+
+<div class="w-full h-full px-4 flex flex-col gap-4">
+    <MudText Typo="@Typo.h4">
+        Nhà cung cấp
+    </MudText>
+
+    <MudPaper Class="w-full flex! flex-col! gap-4">
+        <div class="p-4! flex flex-wrap gap-4 items-center">
+            <MudTextField T="string" Value="searchName" ValueChanged="OnSearchNameChanged" 
+                Label="Tìm theo tên" Placeholder="Nhập tên..." Variant="Variant.Outlined" 
+                Margin="Margin.Dense" Style="flex: 1; min-width: 200px;" Clearable="true" Adornment="Adornment.Start" 
+                AdornmentIcon="@Icons.Material.Filled.Search" Immediate="true" 
+                DebounceInterval="300" OnDebounceIntervalElapsed="OnSearchDebounced" />
+            <MudTextField T="string" Value="searchPhone" ValueChanged="OnSearchPhoneChanged" 
+                Label="Tìm theo SĐT" Placeholder="Nhập số điện thoại..." Variant="Variant.Outlined" 
+                Margin="Margin.Dense" Style="flex: 1; min-width: 200px;" Clearable="true" Adornment="Adornment.Start" 
+                AdornmentIcon="@Icons.Material.Filled.Phone" Immediate="true" 
+                DebounceInterval="300" OnDebounceIntervalElapsed="OnSearchPhoneDebounced" />
+            <MudButton Color="Color.Default" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Refresh" 
+                OnClick="OnResetSearch" Style="height: 40px;">Đặt lại</MudButton>
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" 
+                OnClick="OpenCreateDialog" Style="height: 40px;">Thêm</MudButton>
+        </div>
+        @if (selectedItems.Any())
+        {
+            <div class="p-2 flex items-center gap-2">
+                <MudText>Đã chọn @selectedItems.Count mục</MudText>
+                <MudButton Color="Color.Error" Variant="Variant.Filled" Size="Size.Small" 
+                    StartIcon="@Icons.Material.Filled.Delete" OnClick="OpenDeleteMultipleDialog">
+                    Xóa đã chọn
+                </MudButton>
+            </div>
+        }
+        <MudTable Loading=@isLoading Items=@items Bordered=true Class="!border-black" Height="500px" Striped="true"
+            HorizontalScrollbar=true FixedHeader=true MultiSelection=true @bind-SelectedItems="selectedItems">
+            <HeaderContent>
+                <MudTh>Tên</MudTh>
+                <MudTh>SĐT</MudTh>
+                <MudTh>Email</MudTh>
+                <MudTh>Địa chỉ</MudTh>
+                <MudTh Style="width: 150px;">Hành động</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Tên">@context.Name</MudTd>
+                <MudTd DataLabel="SĐT">@context.Phone</MudTd>
+                <MudTd DataLabel="Email">@context.Email</MudTd>
+                <MudTd DataLabel="Địa chỉ">@context.Address</MudTd>
+                <MudTd DataLabel="Hành động">
+                    <div class="flex gap-2">
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" Color="Color.Primary" Size="Size.Small"
+                            OnClick="@(() => OpenEditDialog(context))" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small"
+                            OnClick="@(() => OpenDeleteDialog(context))" />
+                    </div>
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+        <Pagination Props="paginationProps" OnPageChanged="OnPageChanged" OnPageSizeChanged="OnPageSizeChanged">
+        </Pagination>
+    </MudPaper>
+</div>
+
+@* Edit Dialog *@
+<UpdateSupplierDialog @bind-IsVisible="isEditDialogVisible" Model="editModel" OnSubmit="SaveEdit" />
+
+@* Create Dialog *@
+<CreateSupplierDialog @bind-IsVisible="isCreateDialogVisible" Model="createModel" OnSubmit="SaveCreate" />
+
+@* Delete Confirmation Dialog *@
+<MudDialog @bind-Visible="isDeleteDialogVisible">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Xác nhận xóa</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText>Bạn có chắc chắn muốn xóa nhà cung cấp <strong>@selectedSupplier?.Name</strong>?</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="CloseDeleteDialog">Hủy</MudButton>
+        <MudButton Color="Color.Error" OnClick="ConfirmDelete">Xóa</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@* Delete Multiple Confirmation Dialog *@
+<MudDialog @bind-Visible="isDeleteMultipleDialogVisible">
+    <TitleContent>
+        <MudText Typo="Typo.h6">Xác nhận xóa nhiều</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudText>Bạn có chắc chắn muốn xóa <strong>@selectedItems.Count</strong> nhà cung cấp đã chọn?</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="CloseDeleteMultipleDialog">Hủy</MudButton>
+        <MudButton Color="Color.Error" OnClick="ConfirmDeleteMultiple">Xóa</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    #region props and variables
+
+    Response_PagedResponse_SupplierResponse? data;
+    IEnumerable<SupplierResponse> items = [];
+    bool isLoading = true;
+
+    // Search
+    string? searchName;
+    string? searchPhone;
+
+    PaginationProps paginationProps = new PaginationProps()
+    {
+        CurrentPage = 1,
+        PageSize = 10,
+        TotalPages = 0,
+        Placement = GreenStore.Shared.Pagination.Placement.End
+    };
+
+    // Edit dialog
+    bool isEditDialogVisible = false;
+    SupplierDto editModel = new SupplierDto();
+
+    // Create dialog
+    bool isCreateDialogVisible = false;
+    SupplierDto createModel = new SupplierDto();
+
+    // Delete dialog
+    bool isDeleteDialogVisible = false;
+    SupplierResponse? selectedSupplier;
+
+    // Multi-select
+    HashSet<SupplierResponse> selectedItems = new HashSet<SupplierResponse>();
+    bool isDeleteMultipleDialogVisible = false;
+
+    #endregion
+
+    private async Task Fetch()
+    {
+        isLoading = true;
+        StateHasChanged();
+
+        try
+        {
+            int curPage = paginationProps.CurrentPage;
+            int pageSize = paginationProps.PageSize;
+
+            data = await Api.FilterSuppliersAsync(
+                name: string.IsNullOrWhiteSpace(searchName) ? null : searchName,
+                phone: string.IsNullOrWhiteSpace(searchPhone) ? null : searchPhone,
+                pageNumber: curPage, 
+                pageSize: pageSize);
+            items = data?.Data?.Items ?? [];
+            paginationProps.TotalPages = data?.Data?.TotalPages ?? 0;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+            Toast.Add("Không thể tải danh sách nhà cung cấp", Severity.Error);
+        }
+
+        isLoading = false;
+        StateHasChanged();
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await Fetch();
+    }
+
+    private async void OnPageChanged(int page)
+    {
+        paginationProps.CurrentPage = page;
+        await Fetch();
+    }
+
+    private async void OnPageSizeChanged(int pageSize)
+    {
+        paginationProps.PageSize = pageSize;
+        await Fetch();
+    }
+
+    private void OnSearchNameChanged(string value)
+    {
+        searchName = value;
+    }
+
+    private void OnSearchPhoneChanged(string value)
+    {
+        searchPhone = value;
+    }
+
+    private async Task OnSearchDebounced(string value)
+    {
+        searchName = value;
+        paginationProps.CurrentPage = 1;
+        selectedItems.Clear();
+        await Fetch();
+    }
+
+    private async Task OnSearchPhoneDebounced(string value)
+    {
+        searchPhone = value;
+        paginationProps.CurrentPage = 1;
+        selectedItems.Clear();
+        await Fetch();
+    }
+
+    private async Task OnResetSearch()
+    {
+        searchName = null;
+        searchPhone = null;
+        paginationProps.CurrentPage = 1;
+        selectedItems.Clear();
+        await Fetch();
+    }
+
+    #region Create
+
+    private void OpenCreateDialog()
+    {
+        createModel = new SupplierDto();
+        isCreateDialogVisible = true;
+    }
+
+    private async Task SaveCreate(SupplierDto model)
+    {
+        try
+        {
+            await Api.CreateSupplierAsync(model);
+            Toast.Add("Thêm nhà cung cấp thành công", Severity.Success);
+            isCreateDialogVisible = false;
+            await Fetch();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+            Toast.Add("Không thể thêm nhà cung cấp", Severity.Error);
+        }
+    }
+
+    #endregion
+
+    #region Edit
+
+    private void OpenEditDialog(SupplierResponse supplier)
+    {
+        editModel = new SupplierDto
+        {
+            SupplierId = supplier.SupplierId,
+            Name = supplier.Name ?? "",
+            Phone = supplier.Phone,
+            Email = supplier.Email,
+            Address = supplier.Address
+        };
+        isEditDialogVisible = true;
+    }
+
+    private async Task SaveEdit(SupplierDto model)
+    {
+        try
+        {
+            await Api.UpdateSupplierAsync(model.SupplierId, model);
+            Toast.Add("Cập nhật nhà cung cấp thành công", Severity.Success);
+            isEditDialogVisible = false;
+            await Fetch();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+            Toast.Add("Không thể cập nhật nhà cung cấp", Severity.Error);
+        }
+    }
+
+    #endregion
+
+    #region Delete
+
+    private void OpenDeleteDialog(SupplierResponse supplier)
+    {
+        selectedSupplier = supplier;
+        isDeleteDialogVisible = true;
+    }
+
+    private void CloseDeleteDialog()
+    {
+        isDeleteDialogVisible = false;
+        selectedSupplier = null;
+    }
+
+    private async Task ConfirmDelete()
+    {
+        if (selectedSupplier == null) return;
+
+        try
+        {
+            await Api.DeleteSupplierAsync(selectedSupplier.SupplierId);
+            Toast.Add("Xóa nhà cung cấp thành công", Severity.Success);
+            CloseDeleteDialog();
+            await Fetch();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+            Toast.Add("Không thể xóa nhà cung cấp", Severity.Error);
+        }
+    }
+
+    private void OpenDeleteMultipleDialog()
+    {
+        if (!selectedItems.Any()) return;
+        isDeleteMultipleDialogVisible = true;
+    }
+
+    private void CloseDeleteMultipleDialog()
+    {
+        isDeleteMultipleDialogVisible = false;
+    }
+
+    private async Task ConfirmDeleteMultiple()
+    {
+        if (!selectedItems.Any()) return;
+
+        try
+        {
+            var deleteTasks = selectedItems.Select(s => Api.DeleteSupplierAsync(s.SupplierId));
+            await Task.WhenAll(deleteTasks);
+            
+            Toast.Add($"Đã xóa {selectedItems.Count} nhà cung cấp thành công", Severity.Success);
+            selectedItems.Clear();
+            CloseDeleteMultipleDialog();
+            await Fetch();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+            Toast.Add("Không thể xóa một số nhà cung cấp", Severity.Error);
+        }
+    }
+
+    #endregion
+}

--- a/Pages/Supplier/SupplierPage.razor
+++ b/Pages/Supplier/SupplierPage.razor
@@ -16,55 +16,31 @@
 
     <MudPaper Class="w-full flex! flex-col! gap-4">
         <div class="p-4! flex flex-wrap gap-4 items-center">
-            <MudTextField T="string" Value="searchName" ValueChanged="OnSearchNameChanged" 
-                Label="Tìm theo tên" Placeholder="Nhập tên..." Variant="Variant.Outlined" 
+            <MudSelect T="SearchType" Value="searchType" ValueChanged="OnSearchTypeChanged"
+                Label="Tìm theo" Variant="Variant.Outlined" Margin="Margin.Dense" 
+                Style="width: 150px;">
+                <MudSelectItem Value="SearchType.Name">Tên</MudSelectItem>
+                <MudSelectItem Value="SearchType.Phone">Số điện thoại</MudSelectItem>
+            </MudSelect>
+            <MudTextField T="string" Value="searchValue" ValueChanged="OnSearchValueChanged" 
+                Label="@GetSearchLabel()" Placeholder="@GetSearchPlaceholder()" Variant="Variant.Outlined" 
                 Margin="Margin.Dense" Style="flex: 1; min-width: 200px;" Clearable="true" Adornment="Adornment.Start" 
-                AdornmentIcon="@Icons.Material.Filled.Search" Immediate="true" 
+                AdornmentIcon="@GetSearchIcon()" Immediate="true" 
                 DebounceInterval="300" OnDebounceIntervalElapsed="OnSearchDebounced" />
-            <MudTextField T="string" Value="searchPhone" ValueChanged="OnSearchPhoneChanged" 
-                Label="Tìm theo SĐT" Placeholder="Nhập số điện thoại..." Variant="Variant.Outlined" 
-                Margin="Margin.Dense" Style="flex: 1; min-width: 200px;" Clearable="true" Adornment="Adornment.Start" 
-                AdornmentIcon="@Icons.Material.Filled.Phone" Immediate="true" 
-                DebounceInterval="300" OnDebounceIntervalElapsed="OnSearchPhoneDebounced" />
             <MudButton Color="Color.Default" Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Refresh" 
                 OnClick="OnResetSearch" Style="height: 40px;">Đặt lại</MudButton>
             <MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" 
                 OnClick="OpenCreateDialog" Style="height: 40px;">Thêm</MudButton>
+            <MudButton Color="Color.Error" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Delete" 
+                OnClick="OpenDeleteMultipleDialog" Style="height: 40px;" Disabled="@(!selectedItems.Any())">Xóa</MudButton>
         </div>
         @if (selectedItems.Any())
         {
             <div class="p-2 flex items-center gap-2">
                 <MudText>Đã chọn @selectedItems.Count mục</MudText>
-                <MudButton Color="Color.Error" Variant="Variant.Filled" Size="Size.Small" 
-                    StartIcon="@Icons.Material.Filled.Delete" OnClick="OpenDeleteMultipleDialog">
-                    Xóa đã chọn
-                </MudButton>
             </div>
         }
-        <MudTable Loading=@isLoading Items=@items Bordered=true Class="!border-black" Height="500px" Striped="true"
-            HorizontalScrollbar=true FixedHeader=true MultiSelection=true @bind-SelectedItems="selectedItems">
-            <HeaderContent>
-                <MudTh>Tên</MudTh>
-                <MudTh>SĐT</MudTh>
-                <MudTh>Email</MudTh>
-                <MudTh>Địa chỉ</MudTh>
-                <MudTh Style="width: 150px;">Hành động</MudTh>
-            </HeaderContent>
-            <RowTemplate>
-                <MudTd DataLabel="Tên">@context.Name</MudTd>
-                <MudTd DataLabel="SĐT">@context.Phone</MudTd>
-                <MudTd DataLabel="Email">@context.Email</MudTd>
-                <MudTd DataLabel="Địa chỉ">@context.Address</MudTd>
-                <MudTd DataLabel="Hành động">
-                    <div class="flex gap-2">
-                        <MudIconButton Icon="@Icons.Material.Filled.Edit" Color="Color.Primary" Size="Size.Small"
-                            OnClick="@(() => OpenEditDialog(context))" />
-                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small"
-                            OnClick="@(() => OpenDeleteDialog(context))" />
-                    </div>
-                </MudTd>
-            </RowTemplate>
-        </MudTable>
+        <Table TModel="SupplierResponse" Props="tableProps" />
         <Pagination Props="paginationProps" OnPageChanged="OnPageChanged" OnPageSizeChanged="OnPageSizeChanged">
         </Pagination>
     </MudPaper>
@@ -112,8 +88,12 @@
     bool isLoading = true;
 
     // Search
-    string? searchName;
-    string? searchPhone;
+    enum SearchType { Name, Phone }
+    SearchType searchType = SearchType.Name;
+    string? searchValue;
+
+    // Table props
+    TableProps<SupplierResponse> tableProps = null!;
 
     PaginationProps paginationProps = new PaginationProps()
     {
@@ -141,15 +121,87 @@
 
     #endregion
 
+    protected override void OnInitialized()
+    {
+        InitializeTableProps();
+    }
+
+    private void InitializeTableProps()
+    {
+        tableProps = new TableProps<SupplierResponse>
+        {
+            Columns = new List<TableColumn<SupplierResponse>>
+            {
+                new TableColumn<SupplierResponse> { Header = "TÊN", ValueSelector = x => x.Name ?? "", SortSelector = x => x.Name ?? "" },
+                new TableColumn<SupplierResponse> { Header = "SĐT", ValueSelector = x => x.Phone ?? "" },
+                new TableColumn<SupplierResponse> { Header = "EMAIL", ValueSelector = x => x.Email ?? "" },
+                new TableColumn<SupplierResponse> { Header = "ĐỊA CHỈ", ValueSelector = x => x.Address ?? "" }
+            },
+            Items = items,
+            IsLoading = isLoading,
+            IsSelectable = true,
+            SelectedItems = selectedItems,
+            SelectedItemsChanged = EventCallback.Factory.Create<ISet<SupplierResponse>>(this, OnSelectedItemsChanged),
+            Actions = new List<TableAction<SupplierResponse>>
+            {
+                new TableAction<SupplierResponse>
+                {
+                    Icon = Icons.Material.Filled.Edit,
+                    Text = "Chỉnh sửa",
+                    Color = Color.Primary,
+                    OnClick = OpenEditDialog
+                }
+            }
+        };
+    }
+
+    private void UpdateTableProps()
+    {
+        tableProps.Items = items;
+        tableProps.IsLoading = isLoading;
+        tableProps.SelectedItems = selectedItems;
+    }
+
+    private void OnSelectedItemsChanged(ISet<SupplierResponse> items)
+    {
+        selectedItems = items as HashSet<SupplierResponse> ?? new HashSet<SupplierResponse>(items);
+        StateHasChanged();
+    }
+
+    private string GetSearchLabel() => searchType switch
+    {
+        SearchType.Name => "Tìm theo tên",
+        SearchType.Phone => "Tìm theo SĐT",
+        _ => "Tìm kiếm"
+    };
+
+    private string GetSearchPlaceholder() => searchType switch
+    {
+        SearchType.Name => "Nhập tên...",
+        SearchType.Phone => "Nhập số điện thoại...",
+        _ => "Nhập từ khóa..."
+    };
+
+    private string GetSearchIcon() => searchType switch
+    {
+        SearchType.Name => Icons.Material.Filled.Search,
+        SearchType.Phone => Icons.Material.Filled.Phone,
+        _ => Icons.Material.Filled.Search
+    };
+
     private async Task Fetch()
     {
         isLoading = true;
+        UpdateTableProps();
         StateHasChanged();
 
         try
         {
             int curPage = paginationProps.CurrentPage;
             int pageSize = paginationProps.PageSize;
+
+            string? searchName = searchType == SearchType.Name ? searchValue : null;
+            string? searchPhone = searchType == SearchType.Phone ? searchValue : null;
 
             data = await Api.FilterSuppliersAsync(
                 name: string.IsNullOrWhiteSpace(searchName) ? null : searchName,
@@ -166,6 +218,7 @@
         }
 
         isLoading = false;
+        UpdateTableProps();
         StateHasChanged();
     }
 
@@ -186,27 +239,21 @@
         await Fetch();
     }
 
-    private void OnSearchNameChanged(string value)
+    private void OnSearchTypeChanged(SearchType value)
     {
-        searchName = value;
+        searchType = value;
+        searchValue = null;
+        StateHasChanged();
     }
 
-    private void OnSearchPhoneChanged(string value)
+    private void OnSearchValueChanged(string value)
     {
-        searchPhone = value;
+        searchValue = value;
     }
 
     private async Task OnSearchDebounced(string value)
     {
-        searchName = value;
-        paginationProps.CurrentPage = 1;
-        selectedItems.Clear();
-        await Fetch();
-    }
-
-    private async Task OnSearchPhoneDebounced(string value)
-    {
-        searchPhone = value;
+        searchValue = value;
         paginationProps.CurrentPage = 1;
         selectedItems.Clear();
         await Fetch();
@@ -214,8 +261,8 @@
 
     private async Task OnResetSearch()
     {
-        searchName = null;
-        searchPhone = null;
+        searchValue = null;
+        searchType = SearchType.Name;
         paginationProps.CurrentPage = 1;
         selectedItems.Clear();
         await Fetch();
@@ -260,6 +307,7 @@
             Address = supplier.Address
         };
         isEditDialogVisible = true;
+        StateHasChanged();
     }
 
     private async Task SaveEdit(SupplierDto model)

--- a/Shared/Sidebar/Sidebar.razor.scss
+++ b/Shared/Sidebar/Sidebar.razor.scss
@@ -1,11 +1,13 @@
-$sidebar-bg: #005E42FF;
+$sidebar-bg: rgb(255, 255, 255);
 $nav-item-active: rgb(43, 173, 3);
 $nav-item-hover: rgba(54, 229, 1, 0.554);
-$nav-item-text-color: rgb(150, 255, 171);
+$nav-item-text-color: #333333;
+$sidebar-font: 'Montserrat', sans-serif;
 
 .sidebar ::deep {
     .mud-drawer {
         background-color: $sidebar-bg !important;
+        font-family: $sidebar-font !important;
     }
 
     .mud-icon-root {
@@ -21,6 +23,7 @@ $nav-item-text-color: rgb(150, 255, 171);
         .mud-nav-link {
             color: $nav-item-text-color !important;
             align-items: center;
+            font-family: $sidebar-font !important;
         }
 
         .mud-nav-link.active {
@@ -41,6 +44,7 @@ $nav-item-text-color: rgb(150, 255, 171);
     .mud-nav-item.no-effect {
         .mud-nav-link {
             align-items: center;
+            font-family: $sidebar-font !important;
         }
 
         .mud-nav-link.active {

--- a/Shared/Table/Table.razor
+++ b/Shared/Table/Table.razor
@@ -1,7 +1,16 @@
-@typeparam TModel
+﻿@typeparam TModel
 
-<MudTable Loading=@Props.IsLoading Items=@Props.Items Bordered=true Class="!border-black" Height="500px" Striped="true"
-    MultiSelection=@Props.IsSelectable HorizontalScrollbar=true FixedHeader=true>
+<MudTable Loading=@Props.IsLoading 
+          Items=@Props.Items 
+          Bordered=true 
+          Class="border-black!" 
+          Height="500px" 
+          Striped="true"
+          Elevation="0"
+          MultiSelection=@Props.IsSelectable
+          @bind-SelectedItems="selectedHashSet"
+          HorizontalScrollbar=true 
+          FixedHeader=true>
     <ColGroup>
         @if (Props.IsSelectable)
         {
@@ -12,11 +21,16 @@
         {
             <col />
         }
+        @if (Props.HasActions)
+        {
+            // for action column
+            <col style="width: 150px;" />
+        }
     </ColGroup>
     <HeaderContent>
         @foreach (var column in @Props.Columns)
         {
-            <MudTh>
+            <MudTh Style="font-weight: bold;">
                 @if (column.SortSelector is not null)
                 {
                     <MudTableSortLabel SortBy=@column.SortSelector>
@@ -29,11 +43,34 @@
                 }
             </MudTh>
         }
+        @if (Props.HasActions)
+        {
+            <MudTh Style="text-align: center; font-weight: bold;">HÀNH ĐỘNG</MudTh>
+        }
     </HeaderContent>
     <RowTemplate>
         @foreach (var column in @Props.Columns)
         {
             <MudTd DataLabel=@column.Header>@column.ValueSelector(context)</MudTd>
+        }
+        @if (Props.HasActions)
+        {
+            <MudTd DataLabel="Actions" Style="text-align: center;">
+                <div class="d-flex gap-1 justify-center">
+                    @foreach (var action in Props.Actions)
+                    {
+                        @if (action.IsVisible == null || action.IsVisible(context))
+                        {
+                            <MudIconButton Icon="@action.Icon"
+                                          Color="@action.Color"
+                                          Variant="@action.Variant"
+                                          Size="Size.Small"
+                                          title="@action.Text"
+                                          OnClick="@(() => action.OnClick(context))" />
+                        }
+                    }
+                </div>
+            </MudTd>
         }
     </RowTemplate>
 </MudTable>
@@ -41,4 +78,33 @@
 @code {
     [Parameter]
     public required TableProps<TModel> Props { get; set; }
+
+    private HashSet<TModel> _selectedHashSet = new HashSet<TModel>();
+
+    private HashSet<TModel> selectedHashSet
+    {
+        get => _selectedHashSet;
+        set
+        {
+            _selectedHashSet = value;
+            Props.SelectedItems = value;
+            if (Props.SelectedItemsChanged.HasDelegate)
+            {
+                Props.SelectedItemsChanged.InvokeAsync(value);
+            }
+        }
+    }
+
+    protected override void OnParametersSet()
+    {
+        // Sync from Props.SelectedItems to local HashSet
+        if (Props.SelectedItems is HashSet<TModel> hashSet)
+        {
+            _selectedHashSet = hashSet;
+        }
+        else
+        {
+            _selectedHashSet = new HashSet<TModel>(Props.SelectedItems);
+        }
+    }
 }

--- a/Shared/Table/TableProps.cs
+++ b/Shared/Table/TableProps.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Components;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,11 +12,27 @@ namespace GreenStore.Shared.Table
         public Func<TModel, object?>? SortSelector { get; set; }
     }
 
+    public class TableAction<TModel>
+    {
+        public required string Icon { get; set; }
+        public required string Text { get; set; }
+        public required Action<TModel> OnClick { get; set; }
+        public MudBlazor.Color Color { get; set; } = MudBlazor.Color.Primary;
+        public MudBlazor.Variant Variant { get; set; } = MudBlazor.Variant.Text;
+        public Func<TModel, bool>? IsVisible { get; set; }
+    }
+
     public class TableProps<TModel>
     {
         public required IEnumerable<TableColumn<TModel>> Columns;
         public IEnumerable<TModel> Items { get; set; } = [];
         public bool IsLoading = false;
         public bool IsSelectable = false;
+        public ISet<TModel> SelectedItems { get; set; } = new HashSet<TModel>();
+        public EventCallback<ISet<TModel>> SelectedItemsChanged { get; set; }
+        
+        // Actions for each row
+        public List<TableAction<TModel>> Actions { get; set; } = new List<TableAction<TModel>>();
+        public bool HasActions => Actions != null && Actions.Any();
     }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,12 @@ module.exports = {
     "./**/*.html"
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Montserrat', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        montserrat: ['Montserrat', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 }

--- a/wwwroot/css/styles.css
+++ b/wwwroot/css/styles.css
@@ -1,1 +1,10 @@
 @import "tailwindcss";
+
+@theme {
+  --font-sans: 'Montserrat', ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
+/* Apply Montserrat font globally */
+body {
+  font-family: 'Montserrat', sans-serif;
+}

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -9,7 +9,9 @@
     <link rel="stylesheet" type="text/css" href="css/site.css?version=1.0.0" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <link type="text/css" href="GreenStore.styles.css?version=1.0.0" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css?v=1" rel="stylesheet" />
     <script src="_content/MudBlazor/MudBlazor.min.js?v=1"></script>


### PR DESCRIPTION
This pull request introduces full CRUD (Create, Read, Update, Delete) functionality for the Supplier entity in our Blazor application.

### Summary of Changes

**1. Supplier Services / Repository**

Added a dedicated service/repository layer to handle all CRUD operations for Supplier.
Includes:
* GetAllSuppliersAsync()
* GetSupplierByIdAsync()
* CreateSupplierAsync()
* UpdateSupplierAsync()
* DeleteOrDeactivateSupplierAsync()

**2. Supplier List Component**

* Implemented a searchable list of suppliers.
* Added search functionality by: company name and phone number
* Included reusable table UI and loading indicators.

<img width="1919" height="1040" alt="image" src="https://github.com/user-attachments/assets/1fa2bb0c-f7db-4fb3-8a60-e5d5794e8fe8" />

**3. Supplier Create Component**

New component for creating suppliers.
Features:
* Validation
* Error display
* Submission feedback

<img width="1919" height="1199" alt="image" src="https://github.com/user-attachments/assets/63c19759-a973-49d0-8de2-ce7c0f6a5715" />

**4. Supplier Update Component**

Added component to modify supplier details, including:
* Contact person changes
* Address updates
* Pre-fills form with existing data.

<img width="1919" height="1025" alt="image" src="https://github.com/user-attachments/assets/1b8576a4-09d4-470e-aff3-239e9786115b" />

**5. Supplier Delete**

Implemented delete with confirmation dialog

<img width="1919" height="1021" alt="image" src="https://github.com/user-attachments/assets/3d2588e2-ad53-405a-9c1a-ccccdc556c8b" />
